### PR TITLE
Require newlines inbetween import groups

### DIFF
--- a/core.js
+++ b/core.js
@@ -297,7 +297,8 @@ module.exports = {
     // documented default is not correct, specifying manually
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#options
     'import/order': ['error', {
-      groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      'newlines-between': 'always',
     }],
     'import/prefer-default-export': 'error',
 

--- a/test/react_combined.js
+++ b/test/react_combined.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 
 var react = require('../react');
+
 var start = require('./index_combined');
 
 

--- a/test/test_combined.js
+++ b/test/test_combined.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 
 var test = require('../test');
+
 var start = require('./index_combined');
 
 


### PR DESCRIPTION
First off I wanted to say thanks for making this config. We agree on almost everything style wise, which I have not found in any other config preset. I am not sure what your process is for adding new rules, so I figured I would just send a pull.

It is just one simple change, but I have always liked keeping my [import types separate](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#newlines-between-ignorealwaysnever).

Also, I wasn't sure what the scope in the commit message should be, I can change it if need be.
