### PR TITLE
feat(scripts): Allow the usage of `process.env` with scripts preset

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'no-console': 'off',
     'no-sync': 'off',
+    'no-process-env': 'off',
 
     'import/imports-first': 'off',
     'import/no-extraneous-dependencies': 'off',


### PR DESCRIPTION
Using `process.env` can be pretty useful inside build scripts and the like.