### PR TITLE
feat(rules): Allow newlines inside import groups

### DIFF
--- a/core.js
+++ b/core.js
@@ -297,7 +297,8 @@ module.exports = {
     // documented default is not correct, specifying manually
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#options
     'import/order': ['error', {
-      groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      'newlines-between': 'always-and-inside-groups',
     }],
     'import/prefer-default-export': 'error',
 

--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
     "commitmsg": "validate-commit-msg"
   },
   "dependencies": {
+    "@scottnonnenberg/eslint-plugin-thehelp": "0.3.2",
     "eslint": "2.11.1",
     "eslint-plugin-bdd": "2.1.0",
     "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-filenames": "1.0.0",
     "eslint-plugin-immutable": "1.0.0",
-    "eslint-plugin-import": "1.8.0",
+    "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jsx-a11y": "1.2.3",
     "eslint-plugin-no-loops": "0.2.0",
     "eslint-plugin-react": "5.1.1",
-    "eslint-plugin-security": "1.2.0",
-    "@scottnonnenberg/eslint-plugin-thehelp": "0.3.2"
+    "eslint-plugin-security": "1.2.0"
   },
   "devDependencies": {
     "eslint-find-rules": "1.10.0",

--- a/test/react_combined.js
+++ b/test/react_combined.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 
 var react = require('../react');
+
 var start = require('./index_combined');
 
 

--- a/test/test_combined.js
+++ b/test/test_combined.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 
 var test = require('../test');
+
 var start = require('./index_combined');
 
 


### PR DESCRIPTION
See for reference #2

My [new option ](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever)(`always-and-inside-groups`, see benmosher/eslint-plugin-import#628) for the `'import/order'` rule landed in `eslint-plugin-import` and was published as part of version `2.3.0`. This pull updates the version of `eslint-plugin-import` and enables the new option.

It does make the tests fail though, because there are a number of new rules in `eslint-plugin-import`  that `eslint-find-rules` reports as unused.